### PR TITLE
Ubutnu 16.10 also miss /etc/profile.d/vte.sh

### DIFF
--- a/_manual/vteconfig.md
+++ b/_manual/vteconfig.md
@@ -31,7 +31,7 @@ if [ $TERMINIX_ID ] || [ $VTE_VERSION ]; then
 fi
 {% endhighlight %}
 
-On Ubuntu (16.04), a symlink is probably missing. You can create it with: 
+On Ubuntu (16.04 or 16.10), a symlink is probably missing. You can create it with: 
 {% highlight bash %}
 ln -s /etc/profile.d/vte-2.91.sh /etc/profile.d/vte.sh
 {% endhighlight %}


### PR DESCRIPTION
Freshly installed Ubuntu:

```bash
$ cat /etc/os-release 
NAME="Ubuntu"
VERSION="16.10 (Yakkety Yak)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 16.10"
VERSION_ID="16.10"
HOME_URL="http://www.ubuntu.com/"
SUPPORT_URL="http://help.ubuntu.com/"
BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="http://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=yakkety
UBUNTU_CODENAME=yakkety
```

```bash
$ ls -la /etc/profile.d/vte.sh
ls: cannot access '/etc/profile.d/vte.sh': No such file or directory
```